### PR TITLE
Use automatic Docker API version detection

### DIFF
--- a/shipwright/cli.py
+++ b/shipwright/cli.py
@@ -251,7 +251,7 @@ def process_arguments(path, arguments, client_cfg, environ):
     if tls_config is not None:
         tls_config.assert_hostname = assert_hostname
 
-    client = docker.APIClient(version='1.18', **client_cfg)
+    client = docker.APIClient(version='auto', **client_cfg)
     commands = ['build', 'push', 'images']
     command_names = [c for c in commands if arguments.get(c)]
     command_name = command_names[0] if command_names else 'build'


### PR DESCRIPTION
Setting version to "auto" will automatically detect and use the Servers preferred API version - see https://docker-py.readthedocs.io/en/stable/client.html for more details.

Setting this prevents the following warning from being displayed on every shipwright command when using an up-to-date Docker install:
```
/lib/python3.6/site-packages/docker/api/client.py:155: UserWarning: The minimum API version supported is 1.21, but you are using version 1.18. It is recommended you either upgrade Docker Engine or use an older version of Docker SDK for Python.
  'Python.'.format(MINIMUM_DOCKER_API_VERSION, self._version)
```
